### PR TITLE
Fix duplicate snake reset

### DIFF
--- a/games/snake/src/snake.js
+++ b/games/snake/src/snake.js
@@ -424,14 +424,6 @@ export class Snake {
     return [...this.body];
   }
 
-  /**
-   * Reset snake to initial state
-   */
-  reset() {
-    this.disposeMeshes();
-    this.direction = { x: 1, y: 0 };
-    this.init();
-  }
 
   /**
    * Create death effect animation
@@ -484,18 +476,21 @@ export class Snake {
    * Reset snake to initial state
    */
   reset() {
-    // Reset direction
+    // Dispose of existing meshes
+    this.disposeMeshes();
+
+    // Reset direction and state
     this.direction = { x: 1, y: 0 };
     this.growing = false;
-    
-    // Reset body to initial state
+
+    // Rebuild starting body
     const center = this.grid.getCenterPosition();
     this.body = [
       { x: center.x, y: center.y },
       { x: center.x - 1, y: center.y },
       { x: center.x - 2, y: center.y }
     ];
-    
+
     // Recreate meshes
     this.createMeshes();
   }


### PR DESCRIPTION
## Summary
- remove duplicated `reset` in `snake.js`
- combine reset logic to handle body rebuild, meshes, and direction

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866f1f1f5e4832da6c7e38126b3a0f5