### PR TITLE
Remove automatic initial power-up spawn

### DIFF
--- a/games/snake/src/game.js
+++ b/games/snake/src/game.js
@@ -141,11 +141,13 @@ export class Game {
     this.food = new Food(this.scene, this.grid);
     this.spawnFood();
     
-    // Test power-up spawning
-    console.log('DEBUG: Testing power-up spawning at game start');
-    setTimeout(() => {
-      this.spawnPowerUp();
-    }, 2000); // Spawn a test power-up after 2 seconds
+    // Optional debug: spawn a power-up shortly after starting
+    if (window.DEV_START_POWERUP) {
+      console.log('DEBUG: Spawning initial power-up');
+      setTimeout(() => {
+        this.spawnPowerUp();
+      }, 2000);
+    }
   }
 
   setupInput() {


### PR DESCRIPTION
## Summary
- keep start of snake game clean from debug power-up
- allow developers to toggle the old behavior with `window.DEV_START_POWERUP`

## Testing
- `npx eslint@8.57.0 src/game.js` *(fails: BABYLON not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6866f1f70de8832d8cbd3bfa3b282eb5